### PR TITLE
Fixes the build $CPPFLAGS regex halting our builds

### DIFF
--- a/ext/mini_racer_extension/extconf.rb
+++ b/ext/mini_racer_extension/extconf.rb
@@ -6,7 +6,7 @@ IS_SOLARIS = RUBY_PLATFORM =~ /solaris/
 
 have_library('pthread')
 have_library('objc') if IS_DARWIN
-$CPPFLAGS.gsub! /-std=\w+/, ''
+$CPPFLAGS.gsub! /-std=[^\s]+/, ''
 $CPPFLAGS += " -Wall" unless $CPPFLAGS.split.include? "-Wall"
 $CPPFLAGS += " -g" unless $CPPFLAGS.split.include? "-g"
 $CPPFLAGS += " -rdynamic" unless $CPPFLAGS.split.include? "-rdynamic"


### PR DESCRIPTION
In its current form, the gsub replaces `-std=iso9899:1999` present in our environment with `:1999` which causes our gem native build to barf with ‘:1999 not found’.

Replacing all non-whitespace characters should properly eliminate the whole flag.