### PR TITLE
Work around bad memset detection on ruby 2.3.0

### DIFF
--- a/ext/mini_racer_extension/mini_racer_extension.cc
+++ b/ext/mini_racer_extension/mini_racer_extension.cc
@@ -8,8 +8,18 @@
 # undef HAVE_BUILTIN___BUILTIN_CHOOSE_EXPR_CONSTANT_P
 # undef HAVE_BUILTIN___BUILTIN_TYPES_COMPATIBLE_P
 
-#include <ruby.h>
 #include <ruby/version.h>
+
+// workaround for Ruby 2.3.0 on macOS
+#if RUBY_API_VERSION_CODE == 20300
+#ifdef _DARWIN_C_SOURCE
+#ifndef __STDC_LIB_EXT1__
+#undef HAVE_MEMSET_S
+#endif
+#endif
+#endif
+
+#include <ruby.h>
 #if RUBY_API_VERSION_MAJOR > 1
 #include <ruby/thread.h>
 #endif


### PR DESCRIPTION
We started including `ruby.h` between 0.2.4 sqreen1 and sqreen2, which in turns includes `missing.h` which on 2.3.0 has the following:

```
#ifndef HAVE_EXPLICIT_BZERO
RUBY_EXTERN void explicit_bzero(void *b, size_t len);
# ifdef HAVE_MEMSET_S
# include <string.h>
static inline void
explicit_bzero_by_memset_s(void *b, size_t len)
{
    memset_s(b, len, 0, len);
}
#   define explicit_bzero(b, len) explicit_bzero_by_memset_s(b, len)
# elif defined SecureZeroMemory
#   define explicit_bzero(b, len) SecureZeroMemory(b, len)
# endif
#endif
```

Somehow `memset_s` detection is incorrect. Forcing it with `# undef HAVE_MEMSET_S`.